### PR TITLE
[Feat] 회원가입 안내 및 에러 문구 출력

### DIFF
--- a/src/apis/sign.ts
+++ b/src/apis/sign.ts
@@ -98,7 +98,7 @@ export const useSignUp = () => {
       navigate('/login');
     },
     onError: () => {
-      toast.error('회원가입에 실패했습니다. 다시 시도해주세요.');
+      toast.error('회원가입에 실패했습니다. solved.ac 인증을 확인하세요.');
     },
   });
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -69,6 +69,12 @@ const ERROR_MESSAGES: ErrorMessages = {
   PASSWORD_CHECK: '비밀번호를 확인해주세요.',
 };
 
+const FEEDBACK_MESSAGES = {
+  INVALID_NICKNAME: '유효한 닉네임을 입력하세요.',
+  ENCRYPTION_GUIDE: '암호화키를 solved.ac 내정보-이름에 입력하세요.',
+  INCOMPLETE_FORM: '가입정보를 입력하세요.',
+};
+
 const Signup = () => {
   const signUpMutation = useSignUp();
   const getEncryptionMutation = useGetEncryption();
@@ -125,7 +131,7 @@ const Signup = () => {
           setErrors(prev => ({
             ...prev,
             passwordConfirm: '',
-            passwordSuccess: '비밀번호가 일치합니다',
+            passwordSuccess: '비밀번호가 일치합니다.',
           }));
         }
     }
@@ -145,6 +151,10 @@ const Signup = () => {
         setEncryptionKey(data.verificationCode);
         setIsKeyIssued(true);
         setErrors(prev => ({ ...prev, encryption: '', username: '' }));
+        toast.success(FEEDBACK_MESSAGES.ENCRYPTION_GUIDE);
+      },
+      onError: () => {
+        toast.error(FEEDBACK_MESSAGES.INVALID_NICKNAME);
       },
     });
   };
@@ -352,7 +362,7 @@ const Signup = () => {
                         handleInputChange(e.target.value, 'password')
                       }
                       className='h-10 bg-zinc-900 pr-10 text-zinc-100'
-                      placeholder='비밀번호를 입력하세요'
+                      placeholder='비밀번호를 입력하세요.'
                     />
                     {isShowPassword ? (
                       <EyeOff
@@ -382,7 +392,7 @@ const Signup = () => {
                       handleInputChange(e.target.value, 'passwordConfirm')
                     }
                     className='h-10 bg-zinc-900 text-zinc-100'
-                    placeholder='비밀번호를 다시 입력하세요'
+                    placeholder='비밀번호를 다시 입력하세요.'
                   />
                   {errors.passwordConfirm && (
                     <p className='text-sm text-red-500'>
@@ -395,14 +405,47 @@ const Signup = () => {
                     </p>
                   )}
                 </div>
+                <TooltipProvider>
+                  {!isValid && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className='inline-block w-full'>
+                          <Button
+                            type='submit'
+                            disabled={true}
+                            className='mt-6 h-10 w-full bg-blue-600 hover:bg-blue-700'
+                          >
+                            회원가입
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side='bottom'
+                        sideOffset={28}
+                        className='bg-white px-8 text-black'
+                      >
+                        <p>{FEEDBACK_MESSAGES.INCOMPLETE_FORM}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {isValid && (
+                    <Button
+                      type='submit'
+                      className='mt-6 h-10 w-full bg-blue-600 hover:bg-blue-700'
+                    >
+                      회원가입
+                    </Button>
+                  )}
+                </TooltipProvider>
 
-                <Button
+                {/* <Button
                   type='submit'
                   disabled={!isValid}
                   className='mt-6 h-10 w-full bg-blue-600 hover:bg-blue-700'
+                  title={!isValid ? FEEDBACK_MESSAGES.INCOMPLETE_FORM : ''}
                 >
                   회원가입
-                </Button>
+                </Button> */}
               </form>
             </CardContent>
           </Card>


### PR DESCRIPTION
## 💬 Issue Number

> closes #62 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명
1. 닉네임 입력 후 키 발급 클릭했을 때 미인증된 사용자면
- "유효한 닉네임을 입력하세요"

2. 암호화 키 발급 후
- "암호화키를 solved.ac 내 정보 - 이름에 입력하세요" 안내문구

3. 회원가입 버튼 눌러서 폼 제출 후
- 에러 시: "solved.ac 인증 확인하세요"

4. 회원가입 버튼 활성화에 대한 메세지
- 비활성화일 때 버튼에 마우스 올리면 "가입정보를 입력하세요"

## 📷 Screenshots

> 작업 결과물
![image](https://github.com/user-attachments/assets/204d49c4-25be-4155-9b13-e397caf51ef6)
![image](https://github.com/user-attachments/assets/4131176f-bffd-41ac-84d3-8794af6483cb)
![image](https://github.com/user-attachments/assets/e6ac5acf-ed5d-4772-855d-a8ff17de2611)
![image](https://github.com/user-attachments/assets/0597e61f-7623-426d-ab95-0148c617f043)

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
